### PR TITLE
Pass in host into client instantiation

### DIFF
--- a/lib/bloom_remit_client.rb
+++ b/lib/bloom_remit_client.rb
@@ -42,8 +42,10 @@ module BloomRemitClient
     attr_accessor :sandbox
     attr_writer :host
 
-    def new(*args)
-      client = Client.new(*args)
+    def new(args)
+      client_args = args
+      client_args[:host] ||= self.host
+      client = Client.new(client_args)
       raise ArgumentError, client.errors.full_messages if client.invalid?
       client
     end

--- a/lib/bloom_remit_client/client.rb
+++ b/lib/bloom_remit_client/client.rb
@@ -7,8 +7,9 @@ module BloomRemitClient
     attribute :api_token, String
     attribute :api_secret, String
     attribute :agent_id, String
+    attribute :host, String
 
-    validates :api_token, :api_secret, presence: true
+    validates :api_token, :api_secret, :host, presence: true
 
     # GET
     # /api/v1/partners/:api_token/credits
@@ -86,7 +87,7 @@ module BloomRemitClient
 
     # Should overwrite any other `:api_token`, `:api_secret`
     def access_params
-      @access_params ||= attributes.slice(:api_token, :api_secret)
+      @access_params ||= attributes.slice(:host, :api_token, :api_secret)
     end
 
     def default_params

--- a/lib/bloom_remit_client/concerns/has_base_authentification.rb
+++ b/lib/bloom_remit_client/concerns/has_base_authentification.rb
@@ -6,8 +6,9 @@ module BloomRemitClient
         base.class_eval do
           attribute :api_token, String
           attribute :api_secret, String
+          attribute :host, String
 
-          validates :api_token, :api_secret, presence: true
+          validates :api_token, :api_secret, :host, presence: true
         end
       end
     end

--- a/lib/bloom_remit_client/requests/base.rb
+++ b/lib/bloom_remit_client/requests/base.rb
@@ -15,7 +15,7 @@ module BloomRemitClient
           type: type,
           body: body,
           url: {
-            host: ::BloomRemitClient.host,
+            host: host,
             path: path,
             query_params: query_params
           }

--- a/spec/lib/bloom_remit_client/client_spec.rb
+++ b/spec/lib/bloom_remit_client/client_spec.rb
@@ -7,11 +7,13 @@ module BloomRemitClient
       subject { described_class }
       it { is_expected.to have_attribute(:api_token, String) }
       it { is_expected.to have_attribute(:api_secret, String) }
+      it { is_expected.to have_attribute(:host, String) }
     end
 
     describe "validations" do
       it { is_expected.to validate_presence_of(:api_token) }
       it { is_expected.to validate_presence_of(:api_secret) }
+      it { is_expected.to validate_presence_of(:host) }
     end
 
   end

--- a/spec/lib/bloom_remit_client/requests/base_spec.rb
+++ b/spec/lib/bloom_remit_client/requests/base_spec.rb
@@ -8,11 +8,27 @@ module BloomRemitClient
         subject { described_class }
         it { is_expected.to have_attribute(:api_token, String) }
         it { is_expected.to have_attribute(:api_secret, String) }
+        it { is_expected.to have_attribute(:host, String) }
       end
 
       describe "validations" do
         it { is_expected.to validate_presence_of(:api_token) }
         it { is_expected.to validate_presence_of(:api_secret) }
+        it { is_expected.to validate_presence_of(:host) }
+      end
+
+      describe "#params" do
+        let(:request_class) do
+          Class.new(described_class) do
+            def type; Requests::GET; end
+            def path; "/path"; end
+          end
+        end
+        let(:request) { request_class.new(host: "abc.com") }
+
+        it "uses the host set in the base request" do
+          expect(request.params[:url][:host]).to eq "abc.com"
+        end
       end
 
     end

--- a/spec/lib/bloom_remit_client_spec.rb
+++ b/spec/lib/bloom_remit_client_spec.rb
@@ -15,6 +15,29 @@ RSpec.describe BloomRemitClient do
         expect(client.api_secret).to eq "123"
         expect(client.agent_id).to eq "123"
       end
+
+      context "host is not given" do
+        it "defaults :host to BloomRemitClient.host" do
+          client = described_class.new({
+            api_token: "asd",
+            api_secret: "123",
+            agent_id: "123",
+          })
+          expect(client.host).to eq described_class::STAGING
+        end
+      end
+
+      context "host is given" do
+        it "defaults :host to BloomRemitClient.host" do
+          client = described_class.new({
+            api_token: "asd",
+            api_secret: "123",
+            agent_id: "123",
+            host: "abc.com",
+          })
+          expect(client.host).to eq "abc.com"
+        end
+      end
     end
 
     describe "given invalid credentials" do


### PR DESCRIPTION
This is more threadsafe. If BloomRemitClient.sandbox is changed after instantiation, then successive calls to the instance will not change the host.